### PR TITLE
Modernise and add Mac Support

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,0 +1,42 @@
+const times = require('whisk/times');
+
+const RESPONSE_SIZE = 0x20;
+const REQUEST_PADDING = times(RESPONSE_SIZE).map(() => 0);
+
+const vendorList = [0x1430];
+const productList = [
+  0x1f17,  // usb wired (pc, xbox)
+  0x0150   // wii wireless (also ps3?)
+];
+
+// initialise the command prefixes which matches index for index with
+// the product list
+const commandPrefixes = [
+  [0x0B, 0x14],
+  []
+];
+
+// initialise the input endpoints for the various product ids
+const inpoints = [
+  0x81
+];
+// initialise the output endpoints for the various product ids
+const outpoints = [
+  0x02
+];
+
+function isPortal(device) {
+  return vendorList.includes(device.deviceDescriptor.idVendor)
+    && productList.includes(device.deviceDescriptor.idProduct);
+}
+
+module.exports = {
+  RESPONSE_SIZE,
+  REQUEST_PADDING,
+  vendorList,
+  productList,
+  commandPrefixes,
+  inpoints,
+  outpoints,
+  isPortal
+};

--- a/examples/green-portal.js
+++ b/examples/green-portal.js
@@ -2,5 +2,8 @@ var skyportal = require('../');
 var commands = skyportal.commands;
 
 skyportal.init(function(err, portal) {
+  if (err) {
+    throw err;
+  }
   skyportal.send(commands.color(0, 255, 0), portal);
 });

--- a/examples/green-portal.js
+++ b/examples/green-portal.js
@@ -1,9 +1,4 @@
-var skyportal = require('../');
-var commands = skyportal.commands;
+const skyportal = require('../');
+const commands = skyportal.commands;
 
-skyportal.init(function(err, portal) {
-  if (err) {
-    throw err;
-  }
-  skyportal.send(commands.color(0, 255, 0), portal);
-});
+skyportal.init().then(portal => portal.write(commands.color(0, 255, 0)));

--- a/examples/query-data.js
+++ b/examples/query-data.js
@@ -1,44 +1,16 @@
-var skyportal = require('../');
-var commands = skyportal.commands;
-var async = require('async');
+const skyportal = require('../');
+const async = require('async');
+const times = require('whisk/times');
+const commands = skyportal.commands;
 
-skyportal.init(function(err, portal) {
+skyportal.init().then(portal => {
+  const promises = times(64).map(blockIndex => {
+    return portal
+      .write(commands.query(0x01, blockIndex))
+      .then(() => portal.read());
+  });
 
-  function query(blockIdx, callback) {
-    skyportal.send(commands.query(0x01, blockIdx), portal, function(err) {
-      var lastResponse = [];
-
-      if (err) {
-        return;
-      }
-
-      async.until(
-        function() {
-          return lastResponse[0] === 0x51;
-        },
-
-        function(callback) {
-          skyportal.read(portal, function(err, bytes) {
-            lastResponse = bytes || [];
-            callback(err);
-          });
-        },
-
-        function(err) {
-          if (lastResponse[1] === 0x01) {
-            err = new Error('Portal refused to provide query information');
-          }
-
-          callback(err, lastResponse);
-        }
-      );
-    });
-  }
-
-//   skyportal.send(commands.status(), portal, function(err) {
-//     skyportal.read(portal, function(err, bytes) {
-//     });
-//   });
-
-  async.timesSeries(64, query);
+  Promise.all(promises).then(results => {
+    console.log(results);
+  });
 });

--- a/examples/usb-listdevices.js
+++ b/examples/usb-listdevices.js
@@ -1,0 +1,5 @@
+const usb = require('usb');
+const skyportal = require('..');
+
+// console.log(usb.getDeviceList());
+console.log(skyportal.find());

--- a/examples/usb-listdevices.js
+++ b/examples/usb-listdevices.js
@@ -2,4 +2,7 @@ const usb = require('usb');
 const skyportal = require('..');
 
 // console.log(usb.getDeviceList());
-console.log(skyportal.find());
+const portal = skyportal.find();
+
+portal.device.deviceDescriptor.bDeviceClass = 1;
+console.log(portal);

--- a/index.js
+++ b/index.js
@@ -1,37 +1,10 @@
-/* jshint node: true */
-'use strict';
-
-var commands = exports.commands = require('./commands');
-var debug = require('debug')('skyportal');
-var usb = require('usb');
-var times = require('whisk/times');
-var vendorList = [0x1430];
-var productList = [
-  0x1f17,  // usb wired (pc, xbox)
-  0x0150   // wii wireless (also ps3?)
-];
-
-// initialise the command prefixes which matches index for index with
-// the product list
-var commandPrefixes = [
-  [0x0B, 0x14],
-  []
-];
-
-// initialise the input endpoints for the various product ids
-var inpoints = [
-  0x81
-];
-// initialise the output endpoints for the various product ids
-var outpoints = [
-  0x02
-];
-
-var RESPONSE_SIZE = 0x20;
-var REQUEST_PADDING = times(RESPONSE_SIZE).map(function() {
-  return 0;
-});
-
+const commands = require('./commands');
+const debug = require('debug')('skyportal');
+const usb = require('usb');
+const platform = require('os').platform();
+const platformUtils = require(`./lib/${platform}`);
+const config = require('./config');
+const SkyPortal = require('./portal');
 
 /**
   # skyportal
@@ -74,171 +47,85 @@ var REQUEST_PADDING = times(RESPONSE_SIZE).map(function() {
 **/
 function find(index) {
   // get the portal
-  const device = usb.getDeviceList().filter(isPortal)[index || 0];
+  const device = usb.getDeviceList().filter(config.isPortal)[index || 0];
   if (!device) {
     return;
   }
 
   // find the product index so we can patch in the appropriate command prefix
-  const productIdx = productList.indexOf(device.deviceDescriptor.idProduct);
+  const productIndex = config.productList.indexOf(device.deviceDescriptor.idProduct);
+  debug(`found device; product index = ${productIndex}`);
   return {
-    commandPrefix: commandPrefixes[productIdx] || [],
     device,
-    productIdx
+    productIndex
   };
 }
 
 /**
-  ### skyportal.init(opts?, callback)
+  ### skyportal.init(opts?) => !Promise<SkyPortal>
 
   The `init` function of the skyportal module is best way to get yourself a
   correctly open initialized portal.  In short, you should pretty much
   always use it.
 
 **/
-function init(opts, callback) {
-  var portal;
-  var initCommands = [
+function init(opts) {
+  const targetIndex = (opts || {}).index || 0;
+  const initCommands = [
     commands.reset,
     commands.activate
   ];
 
-  function sendNextInit(err) {
-    if (err) {
-      return callback(err);
-    }
-
-    if (initCommands.length === 0) {
-      return callback(null, portal);
-    }
-
-    send(initCommands.shift(), portal, sendNextInit);
-  }
-
-  if (typeof opts == 'function') {
-    callback = opts;
-    opts = null;
-  }
-
-  open(portal = find((opts || {}).index), sendNextInit);
-  return portal;
-};
+  return open(find(targetIndex))
+    .then(portal => {
+      return initCommands.reduce((memo, command) => {
+        return memo.then(() => portal.write(command));
+      }, Promise.resolve()).then(() => portal);
+    });
+}
 
 /**
-  ### skyportal.open(portal, callback)
+  ### skyportal.open(portal) => Promise<Portal>
 
   Open the portal using the portal data that has been retrieved
   from a find operation.
 
 **/
-function open(portal, callback) {
-  var device = (portal || {}).device;
+function open({ device, productIndex }) {
+  return platformUtils.openDevice(device)
+    .then(device => {
+      debug('opened device successfully');
+      const di = device.interface(0);
+      debug('interface 0 bound');
 
-  // if we don't have a valid device, then abort
-  if (! device) {
-    return callback(new Error('No device data'));
-  }
-
-  try {
-    // open the device
-    device.open();
-  }
-  catch (e) {
-    return callback(wrapUsbError('Could not open the portal', e));
-  }
-
-  // reset the device and then open the interface
-  device.reset(function(err) {
-    var di;
-
-    if (err) {
-      return callback(wrapUsbError('Could not perform reset', err));
-    }
-
-    // select the portal interface
-    di = device.interface(0);
-
-    // if the kernel driver is active for the interface, release
-    if (di.isKernelDriverActive()) {
-      di.detachKernelDriver();
-
-      // flag that we need to reattach the kernel driver
-      portal._reattach = true;
-    }
-
-    // claim the interface (um, horizon)
-    try {
-      di.claim();
-    }
-    catch (e) {
-      return callback(wrapUsbError('Could not claim usb interface', e));
-    }
-
-    // patch in the input and output endpoints
-    portal.i = di.endpoint(inpoints[portal.productIdx] || 0x81);
-    portal.o = di.endpoint(outpoints[portal.productIdx] || 0x02);
-
-    // check the portal input and ouput are value
-    if (!portal.i || portal.i.direction !== 'in') {
-      return callback(new Error('Unable to find input interrupt'));
-    }
-
-    if (!portal.o || portal.o.direction !== 'out') {
-      return callback(new Error('Unable to find output interrupt'));
-    }
-
-    // send the reset signal to the device
-    send(commands.reset(), portal, function(err) {
-      if (err) {
-        return callback(wrapUsbError('Could not send reset command', err));
+      debug('checking kernel driver state');
+      let detachedKernelDriver = false;
+      if (di.isKernelDriverActive()) {
+        debug('kernel drive active, detaching and will reattach on close of this process');
+        di.detachKernelDriver();
+        detachedKernelDriver = true;
       }
 
-      // send the activate and trigger the outer callback
-      send(commands.activate(), portal, function(err) {
-        callback(err, err ? null : portal);
+      di.claim();
+      debug('successfully claimed device');
+      const portal = SkyPortal.of({
+        di,
+        input: di.endpoint(config.inpoints[productIndex] || 0x81),
+        output: di.endpoint(config.outpoints[productIndex] || 0x02),
+        detachedKernelDriver,
+        productIndex
       });
+
+      debug('portal instance created, performing input and output checks');
+      portal.checkInput();
+      portal.checkOutput();
+      debug('input and output ports of configured');
+
+      return portal
+        .write(commands.reset())
+        .then(portal => portal.write(commands.activate()));
     });
-  });
-};
-
-/**
-  ### skyportal.read(portal, callback)
-
-  Read data from the portal.
-
-**/
-function read(portal, callback) {
-  if (!portal || !portal.i) {
-    return callback && callback(new Error('no portal input attached'));
-  }
-
-  var prefixLen = portal.commandPrefix.length;
-  portal.i.transfer(RESPONSE_SIZE, function(err, data) {
-    debug('<-- ', data.length, data);
-    callback(err, err ? null : (prefixLen ? data.slice(prefixLen) : data));
-  });
-};
-
-/**
-  ### skyportal.send(bytes, portal, callback)
-
-  Send a chunk of bytes to the portal. If required the device appropriate
-  command prefix will be prepended to the bytes before sending.
-
-**/
-function send(bytes, portal, callback) {
-  if (!portal || !portal.o) {
-    return callback && callback(new Error('no portal output attached'));
-  }
-
-  // TODO: handle bytes being provided in another format
-  var payload = portal.commandPrefix.concat(bytes || []);
-  var data = new Buffer(payload.concat(REQUEST_PADDING.slice(payload.length)));
-
-  // send the data
-  debug('--> ', data.length, data);
-  portal.o.transfer(data, callback);
-};
+}
 
 function sendRaw(bytes, portal, callback) {
   if (!portal || !portal.o) {
@@ -254,68 +141,11 @@ function sendRaw(bytes, portal, callback) {
   portal.o.transfer(data, callback);
 };
 
-/**
-  ### skyportal.release(portal, callback)
-
-  Release the portal device bindings.
-
-**/
-function release(portal, callback) {
-  var device = (portal || {}).device;
-  var di = device ? device.interface(0) : null;
-
-  // ensure we have a callback
-  callback = callback || function() {};
-
-  // if we don't have a valid device, then abort
-  if (! di) {
-    return callback(new Error('No device data'));
-  }
-
-  di.release(function(err) {
-    if (err) {
-      return callback(err);
-    }
-
-    // release the input and output endpoints
-    portal.i = undefined;
-    portal.o = undefined;
-
-    if (portal._reattach) {
-      di.attachKernelDriver();
-      portal._reattach = false;
-    }
-
-    // release the device reference
-    portal.device = undefined;
-
-    // TODO: close
-    // device.close();
-    callback();
-  });
-};
-
-/* internal functions */
-
-function isPortal(device) {
-  return vendorList.indexOf(device.deviceDescriptor.idVendor) >= 0 &&
-    productList.indexOf(device.deviceDescriptor.idProduct) >= 0;
-}
-
-function wrapUsbError(msg, usbError) {
-  var err = new Error(msg + ' (libusb error: ' + usbError.toString() + ')');
-
-  // attach the usb error
-  err.usb = usbError;
-  return err;
-}
-
 module.exports = {
+  commands,
   find,
   init,
   open,
-  read,
-  send,
   sendRaw,
-  release
+  SkyPortal
 };

--- a/lib/darwin.js
+++ b/lib/darwin.js
@@ -1,0 +1,31 @@
+const async = require('async');
+const debug = require('debug')('skyportal:darwin');
+
+/**
+ * @param {!Device} device
+ * @return {!Promise<Device>}
+ */
+function openDevice(device) {
+  if (!device) {
+    throw new Error('no device selected');
+  }
+
+  debug('opening the device without the default configuration');
+  device.open(false);
+  return new Promise((resolve, reject) => {
+    async.series([
+      device.setConfiguration.bind(device, 1),
+      device.reset.bind(device)
+    ], (err) => {
+      if (err) {
+        return reject(err);
+      }
+
+      resolve(device);
+    })
+  });
+}
+
+module.exports = {
+  openDevice
+};

--- a/lib/linux.js
+++ b/lib/linux.js
@@ -1,0 +1,24 @@
+/**
+ * @param {!Device} device
+ * @return {!Promise<Device>}
+ */
+function openDevice(device) {
+  if (!device) {
+    throw new Error('no device selected');
+  }
+
+  device.open();
+  return new Promise((resolve, reject) => {
+    device.reset((err) => {
+      if (err) {
+        return reject(err);
+      }
+
+      resolve(device);
+    });
+  });
+}
+
+module.exports = {
+  openDevice
+};

--- a/package.json
+++ b/package.json
@@ -21,12 +21,12 @@
     "url": "https://bitbucket.org/DamonOehlman/skyportal/issues"
   },
   "dependencies": {
+    "async": "^2.5.0",
     "debug": "^3.0.0",
     "usb": "^1.2.0",
     "whisk": "^1.3.0"
   },
   "devDependencies": {
-    "async": "^2.5.0",
     "tape": "^4.8.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,12 +21,12 @@
     "url": "https://bitbucket.org/DamonOehlman/skyportal/issues"
   },
   "dependencies": {
-    "debug": "^2.2.0",
-    "usb": "^1.1.2",
+    "debug": "^3.0.0",
+    "usb": "^1.2.0",
     "whisk": "^1.3.0"
   },
   "devDependencies": {
-    "async": "^2.0.0-rc.3",
-    "tape": "^4.5.1"
+    "async": "^2.5.0",
+    "tape": "^4.8.0"
   }
 }

--- a/portal.js
+++ b/portal.js
@@ -1,0 +1,84 @@
+const config = require('./config');
+const debug = require('debug')('skyportal:portal');
+
+class SkyPortal {
+  constructor(options) {
+    this.di = options.di;
+    this.input = options.input;
+    this.output = options.output;
+    this.detachedKernelDriver = options.detachedKernelDriver || false;
+
+    this.commandPrefix = config.commandPrefixes[options.productIndex] || [];
+  }
+
+  static of(options) {
+    return new SkyPortal(options);
+  }
+
+  read() {
+    const prefixLen = this.commandPrefix.length;
+    return new Promise((resolve, reject) => {
+      this.input.transfer(config.RESPONSE_SIZE, (err, data) => {
+        if (err) {
+          return reject(err);
+        }
+
+        debug('<-- ', data.length, data);
+        resolve(data.slice(prefixLen));
+      });
+    });
+  }
+
+  write(bytes) {
+    // TODO: handle bytes being provided in another format
+    const payload = this.commandPrefix.concat(bytes || []);
+    const data = new Buffer(payload.concat(config.REQUEST_PADDING.slice(payload.length)));
+
+    // send the data
+    debug('--> ', data.length, data);
+    return new Promise((resolve, reject) => {
+      this.output.transfer(data, (err) => {
+        if (err) {
+          return reject(err);
+        }
+
+        resolve(this);
+      });
+    });
+  }
+
+  release() {
+    return new Promise((resolve, reject) => {
+      this.di.release((err) => {
+        if (err) {
+          return reject(err);
+        }
+
+        // cleanup references
+        this.input = undefined;
+        this.output = undefined;
+
+        if (this.detachedKernelDriver) {
+          this.di.attachKernelDriver();
+        }
+
+        this.di = undefined;
+        resolve(this);
+      });
+    });
+  }
+
+  checkInput() {
+    if (!this.input || this.input.direction !== 'in') {
+      throw new Error('Unable to find input interrupt');
+    }
+  }
+
+  checkOutput() {
+    if (!this.output || this.output.direction !== 'out') {
+      throw new Error('Unable to find output interrupt');
+    }
+  }
+}
+
+module.exports = SkyPortal;

--- a/system/README.md
+++ b/system/README.md
@@ -1,5 +1,7 @@
 ## Skyportal System File Helpers
 
+### LINUX
+
 To get access working nicely on linux you will need to create an appropriate
 udev rules file for the portal to be able to be accessed by general users. To
 do this, copy the `999-skyportal.rules` file to the `/etc/udev/rules.d/` folder
@@ -11,4 +13,12 @@ commands to have the device accessible from normal users:
 ```
 sudo cp system/999-skyportal.rules /etc/udev/rules.d/
 sudo udevadm control --reload-rules
+```
+
+### MacOS
+
+Listing USB devices:
+
+```
+system_profiler SPUSBDataType
 ```


### PR DESCRIPTION
- Use the updated `usb` package which now supports a `setConfiguration` function to allow initialisation of a device in non-default mode (required for Mac support).

- Modify the API to use a promise style which is pretty useful here.

__TODO:__ need to update the query data examples...